### PR TITLE
WIP Blacklist props

### DIFF
--- a/lib/GlobalStylesheets.js
+++ b/lib/GlobalStylesheets.js
@@ -75,7 +75,7 @@ function createStylesheet(stylesheet) {
   if (Object.keys(focusStyles).length > 0) {
     autoprefix(focusStyles)
     stylesheetText += (
-      '\n.' + PREFIX + stylesheet.id + ':hover {\n' +
+      '\n.' + PREFIX + stylesheet.id + ':focus \n' +
         CSSPropertyOperations.createMarkupForStyles(focusStyles) +
         '\n}\n'
     )
@@ -84,7 +84,7 @@ function createStylesheet(stylesheet) {
   if (Object.keys(activeStyles).length > 0) {
     autoprefix(activeStyles)
     stylesheetText += (
-      '\n.' + PREFIX + stylesheet.id + ':hover {\n' +
+      '\n.' + PREFIX + stylesheet.id + ':active {\n' +
         CSSPropertyOperations.createMarkupForStyles(activeStyles) +
         '\n}\n'
     )

--- a/lib/GlobalStylesheets.js
+++ b/lib/GlobalStylesheets.js
@@ -30,12 +30,65 @@ function addStyle(css){
 
 function createStylesheet(stylesheet) {
   var style = assign({}, stylesheet.style);
+  var hoverStyles = {};
+  var activeStyles = {};
+  var focusStyles = {};
+
+  Object.keys(style).forEach(function(key) {
+    if (key.indexOf('hover') === 0) {
+      // Strip the key of the pseudo selector prefix and transform first char
+      // to lowercase to ensure correct markup generation and autoprefixing
+      var prop = key.substr(5);
+      hoverStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[key];
+      // Remove the key from main style entry
+      delete style[key];
+    }
+    if (key.indexOf('focus') === 0) {
+      var prop = key.substr(5);
+      focusStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[key];
+      delete style[key];
+    }
+    if (key.indexOf('active') === 0) {
+      var prop = key.substr(6);
+      activeStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[key];
+      delete style[key];
+    }
+  });
+
   autoprefix(style);
   var stylesheetText = (
     '\n.' + PREFIX + stylesheet.id + ' {\n' +
       CSSPropertyOperations.createMarkupForStyles(style) +
       '\n}\n'
   );
+
+  // Generate CSS for any pseudo selector props
+  if (Object.keys(hoverStyles).length > 0) {
+    autoprefix(hoverStyles)
+    stylesheetText += (
+      '\n.' + PREFIX + stylesheet.id + ':hover {\n' +
+        CSSPropertyOperations.createMarkupForStyles(hoverStyles) +
+        '\n}\n'
+    )
+  }
+
+  if (Object.keys(focusStyles).length > 0) {
+    autoprefix(focusStyles)
+    stylesheetText += (
+      '\n.' + PREFIX + stylesheet.id + ':hover {\n' +
+        CSSPropertyOperations.createMarkupForStyles(focusStyles) +
+        '\n}\n'
+    )
+  }
+
+  if (Object.keys(activeStyles).length > 0) {
+    autoprefix(activeStyles)
+    stylesheetText += (
+      '\n.' + PREFIX + stylesheet.id + ':hover {\n' +
+        CSSPropertyOperations.createMarkupForStyles(activeStyles) +
+        '\n}\n'
+    )
+  }
 
   return addStyle(stylesheetText);
 }

--- a/lib/GlobalStylesheets.js
+++ b/lib/GlobalStylesheets.js
@@ -75,7 +75,7 @@ function createStylesheet(stylesheet) {
   if (Object.keys(focusStyles).length > 0) {
     autoprefix(focusStyles)
     stylesheetText += (
-      '\n.' + PREFIX + stylesheet.id + ':focus \n' +
+      '\n.' + PREFIX + stylesheet.id + ':focus {\n' +
         CSSPropertyOperations.createMarkupForStyles(focusStyles) +
         '\n}\n'
     )

--- a/lib/extractStyles.js
+++ b/lib/extractStyles.js
@@ -144,6 +144,34 @@ function extractStyles(src, staticNamespace, getClassNameAndComment) {
     var comment = (
       classNameAndComment.comment ? '/* ' + classNameAndComment.comment + ' */\n  ' : ''
     );
+
+    var hoverStyles = {};
+    var focusStyles = {};
+    var activeStyles = {};
+
+    // Check entry for any props with pseudo selector prefixes, move them to
+    // respective pseudo style object
+    Object.keys(entry.staticAttributes).forEach(function(key) {
+      if (key.indexOf('hover') === 0) {
+        // Strip the key of the pseudo selector prefix and transform first char
+        // to lowercase to ensure correct markup generation and autoprefixing
+        var prop = key.substr(5);
+        hoverStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = entry.staticAttributes[key];
+        // Remove the key from main style entry
+        delete entry.staticAttributes[key];
+      }
+      if (key.indexOf('focus') === 0) {
+        var prop = key.substr(5);
+        focusStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = entry.staticAttributes[key];
+        delete entry.staticAttributes[key];
+      }
+      if (key.indexOf('active') === 0) {
+        var prop = key.substr(6);
+        activeStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = entry.staticAttributes[key];
+        delete entry.staticAttributes[key];
+      }
+    });
+
     css += (
       '.' + className + ' {\n  ' +
         comment +
@@ -152,6 +180,40 @@ function extractStyles(src, staticNamespace, getClassNameAndComment) {
         ).split(';').join(';\n  ').trim() +
         '\n}\n\n'
     );
+
+    // Generate CSS for any pseudo selector props
+    if (Object.keys(hoverStyles).length > 0) {
+      css += (
+        '.' + className + ':hover {\n  ' +
+          comment +
+          CSSPropertyOperations.createMarkupForStyles(
+            autoprefix(hoverStyles)
+          ).split(';').join(';\n  ').trim() +
+          '\n}\n\n'
+      )
+    }
+
+    if (Object.keys(focusStyles).length > 0) {
+      css += (
+        '.' + className + ':focus {\n  ' +
+          comment +
+          CSSPropertyOperations.createMarkupForStyles(
+            autoprefix(focusStyles)
+          ).split(';').join(';\n  ').trim() +
+          '\n}\n\n'
+      )
+    }
+
+    if (Object.keys(focusStyles).length > 0) {
+      css += (
+        '.' + className + ':active {\n  ' +
+          comment +
+          CSSPropertyOperations.createMarkupForStyles(
+            autoprefix(activeStyles)
+          ).split(';').join(';\n  ').trim() +
+          '\n}\n\n'
+      )
+    }
   });
 
   evalContext.dispose();

--- a/lib/makeStyleComponentClass.js
+++ b/lib/makeStyleComponentClass.js
@@ -6,6 +6,16 @@ var React = require('react');
 var assign = require('object-assign');
 var autoprefix = require('./autoprefix');
 
+function objectWithoutProperties(obj, keys) {
+  var target = {};
+  for (var i in obj) {
+    if (keys.indexOf(i) >= 0) continue;
+    if (!Object.prototype.hasOwnProperty.call(obj, i)) continue;
+    target[i] = obj[i];
+  }
+  return target;
+}
+
 function getStyleFromProps(props) {
   var style = assign({}, props, {
     children: null,
@@ -17,7 +27,7 @@ function getStyleFromProps(props) {
   return style;
 }
 
-function makeStyleComponentClass(defaults, displayName, tagName) {
+function makeStyleComponentClass(defaults, displayName, tagName, blacklistedProps) {
   tagName = tagName || 'div';
 
   var Style = React.createClass({
@@ -32,7 +42,8 @@ function makeStyleComponentClass(defaults, displayName, tagName) {
     },
 
     refStyleKey: function(props) {
-      this.styleKey = GlobalStylesheets.getKey(getStyleFromProps(props));
+      var rest = blacklistedProps ? objectWithoutProperties(props, blacklistedProps) : props;
+      this.styleKey = GlobalStylesheets.getKey(getStyleFromProps(rest));
       GlobalStylesheets.ref(this.styleKey);
     },
 
@@ -50,16 +61,33 @@ function makeStyleComponentClass(defaults, displayName, tagName) {
     },
 
     render: function() {
-      var style = getStyleFromProps(this.props);
+      var props = blacklistedProps ? objectWithoutProperties(this.props, blacklistedProps) : this.props;
+      var style = getStyleFromProps(props);
       var className = GlobalStylesheets.getClassName(this.styleKey);
-
-      return React.createElement(
-        this.props.component || tagName,
-        {
-          className: (this.props.className || '') + ' ' + className,
-          children: this.props.children,
-        }
-      );
+      if (blacklistedProps) {
+        var propsPayload = {};
+        var self = this;
+        blacklistedProps.forEach(function(e) {
+          propsPayload[e] = self.props[e];
+        })
+        return React.createElement(
+          this.props.component || tagName, assign({},
+          {
+            className: (this.props.className || '') + ' ' + className,
+            children: this.props.children,
+          },
+            propsPayload
+          )
+        );
+      } else {
+        return React.createElement(
+          this.props.component || tagName,
+          {
+            className: (this.props.className || '') + ' ' + className,
+            children: this.props.children,
+          }
+        );
+      }
     }
   });
 

--- a/tests/example.js
+++ b/tests/example.js
@@ -1,5 +1,5 @@
 var React = require('react');
-<Block width="100%" height={25} left={2 * LayoutConstants.x}>
+<Block width="100%" height={25} left={2 * LayoutConstants.x} hoverColor="blue" hoverBackgroundColor="white">
   <InlineBlock height={24} />
   <div style={{width: 10}} />
   <OtherComponent height={25} />

--- a/tests/extractStyles.spec.js
+++ b/tests/extractStyles.spec.js
@@ -11,7 +11,7 @@ describe('extractStyles', function() {
     var rv = extractStyles(EXAMPLE_SRC);
     expect(rv).toEqual({
       js: "var React = require('react');\n<div\n  style={{\n    \"left\": 2 * LayoutConstants.x\n  }}\n  className=\"__s_0\">\n  <div className=\"__s_1\" />\n  <div style={{width: 10}} />\n  <OtherComponent height={25} />\n</div>\n",
-      css: ".__s_0 {\n  width:100%;\n  height:25px;\n  display:block;\n}\n\n.__s_1 {\n  height:24px;\n  display:inline-block;\n}\n\n"
+      css: ".__s_0 {\n  width:100%;\n  height:25px;\n  display:block;\n}\n\n.__s_0:hover {\n  color:blue;\n  background-color:white;\n}\n\n.__s_1 {\n  height:24px;\n  display:inline-block;\n}\n\n"
     });
   });
 
@@ -19,7 +19,7 @@ describe('extractStyles', function() {
     var rv = extractStyles(EXAMPLE_SRC, {LayoutConstants: {x: 10}});
     expect(rv).toEqual({
       js: "var React = require('react');\n<div className=\"__s_0\">\n  <div className=\"__s_1\" />\n  <div style={{width: 10}} />\n  <OtherComponent height={25} />\n</div>\n",
-      css: ".__s_0 {\n  width:100%;\n  height:25px;\n  left:20px;\n  display:block;\n}\n\n.__s_1 {\n  height:24px;\n  display:inline-block;\n}\n\n"
+      css: ".__s_0 {\n  width:100%;\n  height:25px;\n  left:20px;\n  display:block;\n}\n\n.__s_0:hover {\n  color:blue;\n  background-color:white;\n}\n\n.__s_1 {\n  height:24px;\n  display:inline-block;\n}\n\n"
     });
   });
 
@@ -33,7 +33,7 @@ describe('extractStyles', function() {
     });
     expect(rv).toEqual({
       js: "var React = require('react');\n<div className=\"example_line2\">\n  <div className=\"example_line3\" />\n  <div style={{width: 10}} />\n  <OtherComponent height={25} />\n</div>\n",
-      css: ".example_line2 {\n  /* example.js:2 */\n  width:100%;\n  height:25px;\n  left:20px;\n  display:block;\n}\n\n.example_line3 {\n  /* example.js:3 */\n  height:24px;\n  display:inline-block;\n}\n\n"
+      css: ".example_line2 {\n  /* example.js:2 */\n  width:100%;\n  height:25px;\n  left:20px;\n  display:block;\n}\n\n.example_line2:hover {\n  /* example.js:2 */\n  color:blue;\n  background-color:white;\n}\n\n.example_line3 {\n  /* example.js:3 */\n  height:24px;\n  display:inline-block;\n}\n\n"
     });
   });
 });


### PR DESCRIPTION
In tandem with #29 , this PR modifies `makeStyleComponentClass` to optionally accept an array of jsxstyle-blacklisted props to pass to React.
#### Example

``` javascript
import React, { Component } from 'react';
import { Row, Block, Flex } from 'jsxstyle'
import makeStyleComponentClass from 'jsxstyle/lib/makeStyleComponentClass'

const Button = makeStyleComponentClass({display: 'inline'}, 'Button', 'button', ['type'])
const Input = makeStyleComponentClass({display: 'block'}, 'Input', 'input', ['type', 'onChange', 'value'])

class App extends Component {
  constructor () {
    super()
    this.state = {
      text: ''
    }
    this.handleSubmit = this.handleSubmit.bind(this)
    this.handleChange = this.handleChange.bind(this)
  }

  handleSubmit (e) {
    e.preventDefault()
    alert(this.state.text)
  }

  handleChange (e) {
    this.setState({ text: e.target.value })
  }

  render () {
    return (
      <Block margin="4rem">
        <form onSubmit={this.handleSubmit}>
          <Input
            type="text"
            value={this.state.text}
            onChange={this.handleChange}
            border="1px solid #ddd"
            focusBorderColor="#999"
            focusOutline="none"
            marginBottom="2rem"
            padding=".25rem .5rem"
            borderRadius="2px"
            lineHeight="1.6"
            transition="all 200ms ease" />
          <Button
            type="submit"
            border="1px solid #555"
            borderRadius="2px"
            padding=".5rem 2rem"
            transition="all 200ms ease"
            backgroundColor="#fff"
            hoverBackgroundColor="#000"
            color="#555"
            hoverColor="#fff"
            hoverCursor="pointer"
            focusOutline="none">Hover over me</Button>
        </form>
      </Block>
    )
  }
}

export default App
```
