### PR TITLE
Remove the cascade

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>Hello jsxstyle</title>
   </head>
-  <body>
+  <body style="color: red;">
     <div id="container"></div>
     <script src="bundle.js"></script>
   </body>

--- a/example/main.js
+++ b/example/main.js
@@ -11,9 +11,11 @@ ReactDOM.render(
     marginLeft="auto"
     marginRight="auto"
     marginTop="128"
+    fontFamily="Courier New"
     border={'1px solid ' + LayoutConstants.secondaryColor}
     width={48 * LayoutConstants.gridUnit}
     minHeight={64}>
+    Hello world<br />
     <Avatar username="metallica" />
     <Avatar username="justintimberlake" />
     <Avatar username="carlyraejepsen" />

--- a/src/makeStyleComponentClass.js
+++ b/src/makeStyleComponentClass.js
@@ -5,7 +5,35 @@ var React = require('react');
 
 var assign = require('object-assign');
 
-function getStyleFromProps(props) {
+// Subset of inheritable properties we want to disable.
+var INHERITABLE_PROPERTIES = {
+  // TODO: how do we handle the `font` compound property?
+  "color": 'initial',
+  "listStyleType": 'initial',
+  "fontVariant": 'initial',
+  "borderCollapse": 'initial',
+  "fontSize": 'initial',
+  "lineHeight": 'initial',
+  "borderSpacing": 'initial',
+  "wordSpacing": 'initial',
+  "direction": 'initial',
+  "listStylePosition": 'initial',
+  "visibility": 'initial',
+  "fontWeight": 'initial',
+  "letterSpacing": 'initial',
+  "textAlign": 'initial',
+  "emptyCells": 'initial',
+  "fontStyle": 'initial',
+  "fontFamily": 'initial',
+  "cursor": 'initial',
+  "whiteSpace": 'initial',
+  "textIndent": 'initial',
+  "listStyle": 'initial',
+  "listStyleImage": 'initial',
+  "textTransform": 'initial',
+};
+
+function getStyleFromProps(props, inheritableCssProperties) {
   var style = assign({}, props, {
     children: null,
     className: null,
@@ -14,6 +42,13 @@ function getStyleFromProps(props) {
     props: null
   });
   assign(style, props.style);
+
+  for (var key in (inheritableCssProperties || INHERITABLE_PROPERTIES)) {
+    if (!style.hasOwnProperty(key)) {
+      style[key] = INHERITABLE_PROPERTIES[key];
+    }
+  }
+
   return style;
 }
 
@@ -23,6 +58,14 @@ function makeStyleComponentClass(defaults, displayName, tagName) {
   var Style = React.createClass({
     displayName: displayName || 'Style',
 
+    contextTypes: {
+      jsxstyleInheritableCssProperties: React.PropTypes.object,
+    },
+
+    childContextTypes: {
+      jsxstyleInheritableCssProperties: React.PropTypes.object,
+    },
+
     statics: {
       style: defaults
     },
@@ -31,8 +74,28 @@ function makeStyleComponentClass(defaults, displayName, tagName) {
       return defaults;
     },
 
+    getChildContext() {
+      if (!this.inheritableCssProperties) {
+        var style = getStyleFromProps(this.props, this.context.jsxstyleInheritableCssProperties);
+        this.inheritableCssProperties = {};
+        for (var key in style) {
+          if (INHERITABLE_PROPERTIES[key] && style[key] !== 'auto') {
+            this.inheritableCssProperties[key] = true;
+          }
+        }
+      }
+
+      return {
+        jsxstyleInheritableCssProperties: this.inheritableCssProperties,
+      };
+    },
+
     refStyleKey: function(props) {
-      this.styleKey = GlobalStylesheets.getKey(getStyleFromProps(props));
+      var style = getStyleFromProps(props, this.context.jsxstyleInheritableCssProperties);
+
+      // Dirty the inheritableCssProperties cache
+      this.inheritableCssProperties = null;
+      this.styleKey = GlobalStylesheets.getKey(style);
       GlobalStylesheets.ref(this.styleKey);
     },
 
@@ -50,7 +113,6 @@ function makeStyleComponentClass(defaults, displayName, tagName) {
     },
 
     render: function() {
-      var style = getStyleFromProps(this.props);
       var className = GlobalStylesheets.getClassName(this.styleKey);
 
       return React.createElement(


### PR DESCRIPTION
The cascade sort of makes sense for docs but makes less sense for apps. What if we removed it from CSS? This PR is an experiment in achieving this goal.

I've found the cascade to be particularly awful with things like line-height.

**Advantage:** components are guaranteed to look the same no matter where they are used, and styling behaves more similarly to other UI systems

**Disadvantage:** cascading can be convenient. Perhaps we'd introduce `cascadingColor` props which would disable the anti-cascading features.

**How it works:** it does a CSS reset (with `initial`) on the root node, keeps track of which cascading props are set in React's `context`, and resets them in children as needed.
