### PR TITLE
Provide hooks for extracting styles for SSR

### DIFF
--- a/src/GlobalStylesheets.js
+++ b/src/GlobalStylesheets.js
@@ -89,11 +89,13 @@ var GlobalStylesheets = {
         style: styleObj,
         refs: 0,
       };
+      styles[key] = stylesheet;
       if (browser) {
         stylesheet.domNode = createStylesheet(stylesheet);
         document.head.appendChild(stylesheet.domNode);
+      } else if (GlobalStylesheets.injection.createdClass) {
+        GlobalStylesheets.injection.createdClass(getClassName(key), styleObj);
       }
-      styles[key] = stylesheet;
     }
 
     return key;
@@ -110,6 +112,10 @@ var GlobalStylesheets = {
   getClassName(styleKey) {
     return GlobalStylesheets.injection.formatClassNameFromId(styles[styleKey].id);
   },
+  
+  clearStyles: function() {
+    for (var key in styles) delete styles[key];
+  },
 
   injection: {
     getStylesheetId(styleKey, displayName, component) {
@@ -119,6 +125,8 @@ var GlobalStylesheets = {
     formatClassNameFromId(id) {
       return PREFIX + id;
     },
+    
+    createdClass: null
   },
 };
 


### PR DESCRIPTION
_HINT: This is meant as a basis for discussion, not to be merged as is_

I'm currently experimenting with static page generation using react and jsxstyles and found that applying these changes to `GlobalStylesheets.js` allowed me to do some powerful stuff:

When rendering a new page I inject a custom `createdClass` callback which gathers all the styles and associated classnames that were created when calling `renderToStaticMarkup` on the App.
I then can inline this css into the html to have a perfectly styled page and avoid needing an additional css file altogether. 

Here's what my code looks like (I'm using the [static site generator webpack plugin](https://github.com/markdalgleish/static-site-generator-webpack-plugin) to create my pages):

``` jsx
import React from "react";
import {renderToStaticMarkup} from "react-dom/server";
import {ServerRouter} from "react-router";
import App from "./App";
import html from "./index.html";
import GlobalStylesheets from "@danielberndt/jsxstyle/lib/GlobalStylesheets";
import createCSS from "@danielberndt/jsxstyle/lib/createCSS";

export default function render(locals, cb) {
  const inlineStyles = [];
  GlobalStylesheets.injection.createdClass = (className, styles) => {
    inlineStyles.push(createCSS(styles, className));
  }
  const markup = renderToStaticMarkup(
    <ServerRouter location={locals.path} context={context}>
      <App/>
    </ServerRouter>
  );

  GlobalStylesheets.clear(); // to clean up the global styles

  const htmlWithBody = html
    .replace("</head>", `<style>${inlineStyles.join("\n")}</style></head>`)
    .replace('<div id="app"></div>', `<div id="app">${markup}</div>`);

  cb(null, htmlWithBody);
};
```

Is this something you would be happy to support with jsxstyles?
