### PR TITLE
Use inline styles for properties specified in willChange

### DIFF
--- a/src/createCSS.js
+++ b/src/createCSS.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var CSSPropertyOperations = require('react/lib/CSSPropertyOperations');
+var CSSPropertyOperations = require('react-dom/lib/CSSPropertyOperations');
 
 function createCSS(styles, className, comment, pseudoSelector) {
   if (!styles) {

--- a/src/makeStyleComponentClass.js
+++ b/src/makeStyleComponentClass.js
@@ -40,6 +40,10 @@ function extractLocalStyles(styles) {
             );
           }
 
+          if (!willChange.map) {
+            willChange = Array.of(willChange);
+          }
+
           globalStyles[key] = willChange.map(
             styleName => hyphenateStyleName(styleName)
           ).join(', ');

--- a/src/makeStyleComponentClass.js
+++ b/src/makeStyleComponentClass.js
@@ -31,8 +31,16 @@ function extractLocalStyles(styles) {
 
     Object.entries(styles).forEach(
       ([key, value]) => {
-        if (key === 'willChange' && value.length) {
-          globalStyles[key] = value.map(
+        if (key === 'willChange') {
+          let willChange = value;
+
+          if (willChange.includes(',')) {
+            willChange = willChange.split(',').map(
+              untrimmed => untrimmed.trim()
+            );
+          }
+
+          globalStyles[key] = willChange.map(
             styleName => hyphenateStyleName(styleName)
           ).join(', ');
 

--- a/tests/willChange.spec.js
+++ b/tests/willChange.spec.js
@@ -21,6 +21,24 @@ describe("willChange", function() {
     ).toMatch(/transform:translateY\(56px\)/);
   });
 
+  it("parses comma-separated strings", function() {
+    const rendered = ReactDOMServer.renderToString(
+      React.createElement(
+        Col,
+        {
+          willChange: "transform, opacity",
+          transform: "translateY(56px)",
+          opacity: 0,
+          width: "100vw",
+          height: 56,
+        }
+      )
+    );
+
+    expect(rendered).toMatch(/transform:translateY\(56px\)/);
+    expect(rendered).toMatch(/opacity:0/);
+  });
+
   it("will not inline styles that won't change", function() {
     expect(
       ReactDOMServer.renderToString(

--- a/tests/willChange.spec.js
+++ b/tests/willChange.spec.js
@@ -6,19 +6,36 @@ var Col = require('../Col');
 
 describe("willChange", function() {
   it("inlines styles that will change", function() {
-    expect(
-      ReactDOMServer.renderToString(
-        React.createElement(
-          Col,
-          {
-            willChange: ["transform"],
-            transform: "translateY(56px)",
-            width: "100vw",
-            height: 56,
-          }
-        )
+    const rendered = ReactDOMServer.renderToString(
+      React.createElement(
+        Col,
+        {
+          willChange: ["transform"],
+          transform: "translateY(56px)",
+          width: "100vw",
+          height: 56,
+        }
       )
-    ).toMatch(/transform:translateY\(56px\)/);
+    );
+
+    expect(rendered).toMatch(/transform:translateY\(56px\)/);
+  });
+
+  it("accepts a single string property", function() {
+    const rendered = ReactDOMServer.renderToString(
+      React.createElement(
+        Col,
+        {
+          willChange: "transform",
+          transform: "translateY(56px)",
+          opacity: 0,
+          width: "100vw",
+          height: 56,
+        }
+      )
+    );
+
+    expect(rendered).toMatch(/transform:translateY\(56px\)/);
   });
 
   it("parses comma-separated strings", function() {
@@ -40,18 +57,18 @@ describe("willChange", function() {
   });
 
   it("will not inline styles that won't change", function() {
-    expect(
-      ReactDOMServer.renderToString(
-        React.createElement(
-          Col,
-          {
-            willChange: ["transform"],
-            transform: "translateY(56px)",
-            width: "100vw",
-            height: 56,
-          }
-        )
+    const rendered = ReactDOMServer.renderToString(
+      React.createElement(
+        Col,
+        {
+          willChange: ["transform"],
+          transform: "translateY(56px)",
+          width: "100vw",
+          height: 56,
+        }
       )
-    ).not.toMatch(/height:56/);
+    );
+
+    expect(rendered).not.toMatch(/height:56/);
   });
 });

--- a/tests/willChange.spec.js
+++ b/tests/willChange.spec.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var React = require('react');
+var ReactDOMServer = require('react-dom/server');
+var Col = require('../Col');
+
+describe("willChange", function() {
+  it("inlines styles that will change", function() {
+    expect(
+      ReactDOMServer.renderToString(
+        React.createElement(
+          Col,
+          {
+            willChange: ["transform"],
+            transform: "translateY(56px)",
+            width: "100vw",
+            height: 56,
+          }
+        )
+      )
+    ).toMatch(/transform:translateY\(56px\)/);
+  });
+
+  it("will not inline styles that won't change", function() {
+    expect(
+      ReactDOMServer.renderToString(
+        React.createElement(
+          Col,
+          {
+            willChange: ["transform"],
+            transform: "translateY(56px)",
+            width: "100vw",
+            height: 56,
+          }
+        )
+      )
+    ).not.toMatch(/height:56/);
+  });
+});


### PR DESCRIPTION
To avoid trashing the DOM creating global stylesheets for animating properties, use `willChange` as a sentinel that certain styles should be applied inline.  `willChange` is [the same property the browser uses](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) to prepare for an animatable style.

Closes https://github.com/smyte/jsxstyle/issues/53