### PR TITLE
WIP Fix imports

### DIFF
--- a/packages/jsxstyle/README.md
+++ b/packages/jsxstyle/README.md
@@ -197,8 +197,8 @@ Here’s a minimal (untested!) example of jsxstyle server rendering with Koa:
 
 ```jsx
 import { cache } from 'jsxstyle';
-import Koa from 'koa';
-import React from 'react';
+import * as Koa from 'koa';
+import * as React from 'react';
 import { renderToString } from 'react-dom';
 
 import App from './App';

--- a/packages/jsxstyle/jsxstyle.js
+++ b/packages/jsxstyle/jsxstyle.js
@@ -1,5 +1,5 @@
-import invariant from 'invariant';
-import React from 'react';
+import * as invariant from 'invariant';
+import * as React from 'react';
 import { componentStyles, getStyleCache } from 'jsxstyle-utils';
 
 export const cache = getStyleCache();

--- a/packages/jsxstyle/preact/jsxstyle-preact.js
+++ b/packages/jsxstyle/preact/jsxstyle-preact.js
@@ -1,5 +1,5 @@
 /** @jsx h */
-import invariant from 'invariant';
+import * as invariant from 'invariant';
 import { getStyleCache, componentStyles } from 'jsxstyle-utils';
 import { h, Component } from 'preact';
 


### PR DESCRIPTION
`import thing from 'package'` presumes that `package` exports a default.  `invariant` exports a function, so environments that expect ESM behavior (like TypeScript) will fail (since `invariant.default` isn't defined).

Unfortunately, this doesn't build.  `yarn run rollup` correctly calls out:

```
packages/jsxstyle/jsxstyle.js → packages/jsxstyle/jsxstyle.cjs.js, packages/jsxstyle/jsxstyle.es.js...
[!] Error: Cannot call a namespace ('invariant')
packages/jsxstyle/jsxstyle.js (11:2)
 9:
10:   tagName = tagName || 'div';
11:   invariant(typeof displayName === 'string' && displayName !== '', 'makeReactStyleComponentClass expects param 1 to be a valid displayName');
      ^
12:
13:   return _temp = _class = function (_React$Component) {

packages/jsxstyle-utils/jsxstyle-utils.es.js 183ms
packages/jsxstyle-utils/jsxstyle-utils.cjs.js 75ms
```

The most appropriate place to correct this is probably the `invariant` repo, since mixing ESM and CJS is undefined and bug-prone.  Since it appears to be a mirror of FB's internal `invariant`, I have no idea if they'll accept a PR.