### PR TITLE
Add support for domRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,16 +90,18 @@ jsxstyle provides the following seven components:
 | `Box` | _No default styles_ |
 
 All props passed to these components are assumed to be CSS properties.
-There are six exceptions to this rule:
+There are eight exceptions to this rule:
 
 | Property | Type | Description |
 |:---|:--|:---|
-| `component`| `string`,&nbsp;`function`,&nbsp;or&nbsp;`object` | the underlying HTML tag or component to render. Defaults&nbsp;to&nbsp;`'div'` |
-| `props`| `object` | additional props to pass directly to the underlying tag&nbsp;or&nbsp;component. |
-| `mediaQueries` | `object` | an object of media query strings keyed by prefix. More&nbsp;on&nbsp;that&nbsp;[below](#media-queries). |
+| `component`| `string`,&nbsp;`function`,&nbsp;or&nbsp;`object` | The underlying HTML tag or component to render. Defaults&nbsp;to&nbsp;`'div'` |
+| `props`| `object` | Additional props to pass directly to the underlying tag&nbsp;or&nbsp;component. |
+| `mediaQueries` | `object` | An object of media query strings keyed by prefix. More&nbsp;on&nbsp;that&nbsp;[below](#media-queries). |
 | `className` | `string` | Class name to be passed through to the underlying tag&nbsp;or&nbsp;component. |
-| `style` | `any` | _Passed through untouched_ |
-| `ref` | `any` | _Passed through untouched_ |
+| `style` | `any` | _Passed through untouched._ |
+| `key` | `string` | _Handled internally by React._  |
+| `ref` | `function (componentInstance|null)` | _Handled internally by React._  |
+| `domRef` | `function (domElement|null)` | Passed as `ref` to the underlying DOM element.  See [the React ref docs](https://reactjs.org/docs/refs-and-the-dom.html#exposing-dom-refs-to-parent-components) for context. |
 
 
 ## Features

--- a/packages/jsxstyle/README.md
+++ b/packages/jsxstyle/README.md
@@ -73,16 +73,18 @@ jsxstyle provides the following seven components:
 | `Box` | _No default styles_ |
 
 All props passed to these components are assumed to be CSS properties.
-There are six exceptions to this rule:
+There are eight exceptions to this rule:
 
 | Property | Type | Description |
 |:---|:--|:---|
-| `component`| `string`,&nbsp;`function`,&nbsp;or&nbsp;`object` | the underlying HTML tag or component to render. Defaults&nbsp;to&nbsp;`'div'` |
-| `props`| `object` | additional props to pass directly to the underlying tag&nbsp;or&nbsp;component. |
-| `mediaQueries` | `object` | an object of media query strings keyed by prefix. More&nbsp;on&nbsp;that&nbsp;[below](#media-queries). |
+| `component`| `string`,&nbsp;`function`,&nbsp;or&nbsp;`object` | The underlying HTML tag or component to render. Defaults&nbsp;to&nbsp;`'div'` |
+| `props`| `object` | Additional props to pass directly to the underlying tag&nbsp;or&nbsp;component. |
+| `mediaQueries` | `object` | An object of media query strings keyed by prefix. More&nbsp;on&nbsp;that&nbsp;[below](#media-queries). |
 | `className` | `string` | Class name to be passed through to the underlying tag&nbsp;or&nbsp;component. |
-| `style` | `any` | _Passed through untouched_ |
-| `ref` | `any` | _Passed through untouched_ |
+| `style` | `any` | _Passed through untouched._ |
+| `key` | `string` | _Handled internally by React._  |
+| `ref` | `function (componentInstance|null)` | _Handled internally by React._  |
+| `domRef` | `function (domElement|null)` | Passed as `ref` to the underlying DOM element.  See [the React ref docs](https://reactjs.org/docs/refs-and-the-dom.html#exposing-dom-refs-to-parent-components) for context. |
 
 
 ## Features

--- a/packages/jsxstyle/jsxstyle.js
+++ b/packages/jsxstyle/jsxstyle.js
@@ -27,7 +27,16 @@ function factory(displayName, defaultProps, tagName) {
     }
 
     render() {
-      const { props, style, children } = this.props;
+      const { props = {}, style, children, domRef } = this.props;
+
+      if (domRef) {
+        if (typeof this.component === 'string') {
+          props.ref = domRef;
+        } else {
+          props.domRef = domRef;
+        }
+      }
+
       return (
         <this.component {...props} className={this.className} style={style}>
           {children}

--- a/packages/jsxstyle/preact/jsxstyle-preact.js
+++ b/packages/jsxstyle/preact/jsxstyle-preact.js
@@ -27,7 +27,15 @@ function factory(displayName, defaultProps, tagName) {
       this.className = cache.getClassName(props, props.class);
     }
 
-    render({ style, props, children }) {
+    render({ style, props = {}, children, domRef }) {
+      if (domRef) {
+        if (typeof this.component === 'string') {
+          props.ref = domRef;
+        } else {
+          props.domRef = domRef;
+        }
+      }
+
       return (
         <this.component {...props} class={this.className} style={style}>
           {children}


### PR DESCRIPTION
I wrote this after you merged my first PR, but before I saw your comment about `jsxstyle-loader`.  This is a start, but it doesn't address the loader.

Fixes #84