### PR TITLE
Add AMD to published packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lib/
 *.log
 *.es.js
 *.cjs.js
+*.amd.js
 *.d.ts
 stats.json
 .*

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "postinstall": "lerna bootstrap",
     "prettier": "prettier --write {packages/*/{*,*/*},examples/{*,*/*}}.js",
     "release": "npm run eslint && npm run jest && lerna publish",
-    "reset": "rimraf packages/{*,*/*}/{jsxstyle*.{es,cjs}.js,**/*.d.ts}",
-    "rollup": "npm run reset && npm run mktypes && rollup -c && prettier --write packages/{*,*/*}/jsxstyle*.{es,cjs}.js",
+    "reset": "rimraf packages/{*,*/*}/{jsxstyle*.{es,cjs,amd}.js,**/*.d.ts}",
+    "rollup": "npm run reset && npm run mktypes && rollup -c && prettier --write packages/{*,*/*}/jsxstyle*.{es,cjs,amd}.js",
     "rollup_watch": "npm run reset && npm run mktypes && rollup -c -w;",
     "start": "webpack-dev-server --hot --hotOnly --inline --historyApiFallback --config=example/webpack.config.js",
     "update_readme": "echo \"$(<./misc/monorepo-preamble.md)\\n\\n---\\n\\n$(<./packages/jsxstyle/README.md)\" > README.md"

--- a/packages/jsxstyle-utils/package.json
+++ b/packages/jsxstyle-utils/package.json
@@ -9,6 +9,7 @@
   "jsnext:main": "jsxstyle-utils.es.js",
   "types": "jsxstyle-utils.d.ts",
   "dependencies": {
+    "@types/webpack": "^3.8.2",
     "invariant": "^2.2.1"
   },
   "keywords": [

--- a/packages/jsxstyle-utils/src/addStyleToHead.ts
+++ b/packages/jsxstyle-utils/src/addStyleToHead.ts
@@ -1,3 +1,5 @@
+/// <reference types = "@types/webpack-env" />
+
 const canUseDOM = !!(
   typeof window !== 'undefined' &&
   window.document &&
@@ -6,7 +8,7 @@ const canUseDOM = !!(
 
 let styleElement: HTMLStyleElement | undefined;
 
-if (module.hot) {
+if (typeof module !== 'undefined' && module.hot) {
   if (typeof module.hot.data === 'object') {
     styleElement = module.hot.data.styleElement;
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,7 @@ export default [
     output: [
       { format: 'cjs', file: `packages/${pkg}/${filename}.cjs.js` },
       { format: 'es', file: `packages/${pkg}/${filename}.es.js` },
+      { format: 'amd', file: `packages/${pkg}/${filename}.amd.js`, amd: { id: pkg }},
     ],
     plugins: [
       typescript({


### PR DESCRIPTION
The [Bazel build tool](https://github.com/bazelbuild/rules_typescript) currently requires dependencies to be in the AMD format.  This adds AMD to the list of things Rollup spits out.

There are a couple potential changes to be considered before merging:

1. **Should this be combined into the CommonJS export?**

   We could change the CommonJS export to use UMD instead, which would make that same build compatible with both CommonJS and AMD.

2. **How should `jsxstyle-utils` be packaged for the AMD bundle?**

   `jsxstyle-utils` is effectively an internal package; it gets included automatically for npm users.  However, AMD users wouldn't automatically receive it; they'd have to import both the `jsxstyle` and `jsxstyle-utils` bundles.  This seems less than ideal.

   **Here are two strategies for fixing that:**

   a. In `rollup.config.js`, abstract the config boilerplate into a function that decides whether or not to treat `jsxstyle-utils` as an `external` import.  Make it external for `cjs` and `esm`, but not for `amd`.

   b. Leave `rollup.config.js` as-is.  Add a `package.json` script that concatenates `jsxstyle-utils` onto each AMD bundle.

   Of course, both of these resolutions presume we distribute separate bundles for AMD and CommonJS.

Would love to hear your thoughts on these issues.